### PR TITLE
Changed URL to github example's repository ("Elasticsearch is coming" article)

### DIFF
--- a/_posts/2015-07-08-elasticsearch-is-coming.md
+++ b/_posts/2015-07-08-elasticsearch-is-coming.md
@@ -47,7 +47,7 @@ All along these articles (though I don't know how many of them will follow this 
 
 #### The Github Repository
 
-Available here: [https://github.com/quentinfayet/elasticsearch](https://github.com/quentinfayet/elasticsearch)
+Available here: [https://github.com/quentinfayet/elasticsearch/tree/v1.0](https://github.com/quentinfayet/elasticsearch/tree/v1.0)
 
 It contains everything you need to run the articles' examples: A ready-to-run Elasticsearch cluster under Docker containers, available to run with Docker-Compose.
 


### PR DESCRIPTION
I changed the URL to the example's repository, because I needed to make some modifications on it that are not compatible with the second article.

So, I did tag a `v1.0` on the example's repository, and changed the URL in the first article, according to it.
