### PR TITLE
Update Elasticsearch repository tag

### DIFF
--- a/_posts/2015-07-08-elasticsearch-is-coming.md
+++ b/_posts/2015-07-08-elasticsearch-is-coming.md
@@ -47,7 +47,7 @@ All along these articles (though I don't know how many of them will follow this 
 
 #### The Github Repository
 
-Available here: [https://github.com/quentinfayet/elasticsearch/tree/v1.0](https://github.com/quentinfayet/elasticsearch/tree/v1.0)
+Available here: [https://github.com/quentinfayet/elasticsearch/tree/v1.0.1](https://github.com/quentinfayet/elasticsearch/tree/v1.0.1)
 
 It contains everything you need to run the articles' examples: A ready-to-run Elasticsearch cluster under Docker containers, available to run with Docker-Compose.
 

--- a/_posts/2015-10-01-elasticsearch-always-pays-its-debts.md
+++ b/_posts/2015-10-01-elasticsearch-always-pays-its-debts.md
@@ -19,6 +19,8 @@ I advise you to read our first article about Elasticsearch. You can find it here
 
 From the title, you may have guessed that this set of article if following a guideline: Game Of Thrones. In this article, there are no spoilers about the TV show nor the books.
 
+The corresponding Github repository with examples can be found here: [https://github.com/quentinfayet/elasticsearch/tree/v2.0.1](https://github.com/quentinfayet/elasticsearch/tree/v2.0.1).
+
 **Well, let's go!**
 
 ## ROADMAP
@@ -717,7 +719,7 @@ and so on. Nevertheless, I don't want this article to be boring, so I decided to
 
 Before we start making full-text search queries, we should have something on what to search... Which is actually not the case. As my objective right now is not to introduce you
 to high-performance full-text search, we won't need a big database. In my infinite kindness, **I provided you a JSON document you can find in the `dataset` folder of the
-Github repositories that comes with this article**. Okay, you won, I give you the address: [https://github.com/quentinfayet/elasticsearch/tree/v2.0](https://github.com/quentinfayet/elasticsearch/tree/v2.0). This document, named as `game_of_thrones_dataset.json` contains a hand-made
+Github repositories that comes with this article**. Okay, you won, I give you the address: [https://github.com/quentinfayet/elasticsearch/tree/v2.0.1](https://github.com/quentinfayet/elasticsearch/tree/v2.0.1). This document, named as `game_of_thrones_dataset.json` contains a hand-made
 (yes, I said hand-made) dataset of Game of Thrones characters, along with their biographies.
 
 #### The mapping


### PR DESCRIPTION
Due to a bug-fix in the article's repository Dockerfile, I updated the tag version that corresponds to each article.
