### PR TITLE
Fix highlighter

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ url:              http://reputationvip.io
 
 permalink:   /:categories/:title/
 markdown:    kramdown
-highlighter: pygments
+highlighter: rouge
 sass:
   sass_dir: _sass
   style: compressed


### PR DESCRIPTION
`Pygments` highlighter was not supported by Github pages. Switch it to `rouge`
